### PR TITLE
Include mime.types in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ server {
     expires 1h;
     gzip on;
     gzip_types text/text text/html text/plain text/xml text/css application/x-javascript application/javascript application/json;
+    include mime.types;
     types {
         application/json geojson;
         application/gpx+xml gpx;


### PR DESCRIPTION
It looks like it don't work without adding this line in NGINX conf.